### PR TITLE
Fix build on CentOS 7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,5 +7,5 @@ project(FastRdiff)
 find_package(OpenSSL REQUIRED)
 
 add_executable(fastrdiff fastrdiff.cpp)
-target_link_libraries(fastrdiff ssl)
+target_link_libraries(fastrdiff ssl crypto)
 target_link_libraries(fastrdiff log4cpp)


### PR DESCRIPTION
Without fix on centos 7 build fail - 
```
make
Scanning dependencies of target fastrdiff
[100%] Building CXX object CMakeFiles/fastrdiff.dir/fastrdiff.cpp.o
Linking CXX executable fastrdiff
/usr/bin/ld: CMakeFiles/fastrdiff.dir/fastrdiff.cpp.o: неопределённая ссылка на символ «MD4_Init@@libcrypto.so.10»
/usr/lib64/libcrypto.so.10: error adding symbols: DSO missing from command line
collect2: ошибка: выполнение ld завершилось с кодом возврата 1
make[2]: *** [fastrdiff] Ошибка 1
make[1]: *** [CMakeFiles/fastrdiff.dir/all] Ошибка 2
make: *** [all] Ошибка 2
```

Thanks @pavel-odintsov for help with fix.